### PR TITLE
UE5.5対応＆不具合修正

### DIFF
--- a/Plugins/VoicevoxEngine/Source/VoicevoxEngine/Private/VoicevoxAsyncTask.cpp
+++ b/Plugins/VoicevoxEngine/Source/VoicevoxEngine/Private/VoicevoxAsyncTask.cpp
@@ -32,7 +32,7 @@ UVoicevoxInitializeAsyncTask* UVoicevoxInitializeAsyncTask::Initialize(UObject* 
  */
 void UVoicevoxInitializeAsyncTask::Activate()
 {
-	UE::Tasks::Launch<>(TEXT("VoicevoxCoreTask"), [&]
+	Task = UE::Tasks::Launch<>(TEXT("VoicevoxCoreTask"), [&]
 	{
 		if (GEngine->GetEngineSubsystem<UVoicevoxCoreSubsystem>()->Initialize(bUseGPU, CPUNumThreads, false))
 		{
@@ -44,6 +44,15 @@ void UVoicevoxInitializeAsyncTask::Activate()
 		}
 		SetReadyToDestroy();
 	});
+}
+
+/**
+ * @brief BeginDestroy
+ */
+void UVoicevoxInitializeAsyncTask::BeginDestroy()
+{
+	Task.Wait();
+	Super::BeginDestroy();
 }
 
 //------------------------------------------------------------------------
@@ -116,7 +125,7 @@ UVoicevoxTextToSpeechAsyncTask* UVoicevoxTextToSpeechAsyncTask::TextToAudioQuery
  */	
 void UVoicevoxTextToSpeechAsyncTask::Activate()
 {
-	UE::Tasks::Launch<>(TEXT("VoicevoxCoreTextToSpeechTask"), [&]
+	Task = UE::Tasks::Launch<>(TEXT("VoicevoxCoreTextToSpeechTask"), [&]
 	{
 		if (USoundWave* Sound = bIsUseAudioQuery ?
 			UVoicevoxBlueprintLibrary::TextToAudioQueryOutput(SpeakerId, Message, bRunKana, bEnableInterrogativeUpspeak) :
@@ -133,6 +142,15 @@ void UVoicevoxTextToSpeechAsyncTask::Activate()
 		SetReadyToDestroy();
 	});
 
+}
+
+/**
+ * @brief BeginDestroy
+ */
+void UVoicevoxTextToSpeechAsyncTask::BeginDestroy()
+{
+	Task.Wait();
+	Super::BeginDestroy();
 }
 
 //------------------------------------------------------------------------
@@ -179,7 +197,7 @@ void UVoicevoxAudioQueryToSpeechAsyncTask::Activate()
 		return;
 	}
 	
-	UE::Tasks::Launch<>(TEXT("VoicevoxCoreTextToSpeechTask"), [&]
+	Task = UE::Tasks::Launch<>(TEXT("VoicevoxCoreTextToSpeechTask"), [&]
 	{
 		if (USoundWave* Sound = UVoicevoxBlueprintLibrary::AudioQueryOutput(AudioQuery, SpeakerId, bEnableInterrogativeUpspeak);
 			Sound != nullptr)
@@ -194,4 +212,13 @@ void UVoicevoxAudioQueryToSpeechAsyncTask::Activate()
 		SetReadyToDestroy();
 	});
 
+}
+
+/**
+ * @brief BeginDestroy
+ */
+void UVoicevoxAudioQueryToSpeechAsyncTask::BeginDestroy()
+{
+	Task.Wait();
+	Super::BeginDestroy();
 }

--- a/Plugins/VoicevoxEngine/Source/VoicevoxEngine/Public/VoicevoxAsyncTask.h
+++ b/Plugins/VoicevoxEngine/Source/VoicevoxEngine/Public/VoicevoxAsyncTask.h
@@ -54,6 +54,9 @@ UCLASS()
 class VOICEVOXENGINE_API UVoicevoxInitializeAsyncTask : public UVoicevoxAsyncTaskBase
 {
 	GENERATED_BODY()
+
+	//! 実行タスク
+	UE::Tasks::TTask<void> Task;
 public:
 	
 	/**
@@ -77,6 +80,11 @@ public:
 	 * @brief デリゲートがバインドされた後、アクションをトリガーするために呼び出される
 	 */
 	virtual void Activate() override;
+
+	/**
+	 * @brief BeginDestroy
+	 */
+	virtual void BeginDestroy() override;
 };
 
 //------------------------------------------------------------------------
@@ -124,6 +132,10 @@ UCLASS()
 class VOICEVOXENGINE_API UVoicevoxTextToSpeechAsyncTask : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
+
+	//! 実行タスク
+	UE::Tasks::TTask<void> Task;
+	
 public:
 
 	//! 処理成功時のデリゲート
@@ -171,6 +183,11 @@ public:
 	 * @brief デリゲートがバインドされた後、アクションをトリガーするために呼び出される
 	 */	
 	virtual void Activate() override;
+
+	/**
+	 * @brief BeginDestroy
+	 */
+	virtual void BeginDestroy() override;
 };
 
 //------------------------------------------------------------------------
@@ -185,6 +202,10 @@ UCLASS()
 class VOICEVOXENGINE_API UVoicevoxAudioQueryToSpeechAsyncTask : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
+
+	//! 実行タスク
+	UE::Tasks::TTask<void> Task;
+	
 public:
 
 	//! 処理成功時のデリゲート
@@ -225,4 +246,9 @@ public:
 	 * @brief デリゲートがバインドされた後、アクションをトリガーするために呼び出される
 	 */	
 	virtual void Activate() override;
+
+	/**
+	 * @brief BeginDestroy
+	 */
+	virtual void BeginDestroy() override;
 };

--- a/Plugins/VoicevoxNativeCore/Source/VoicevoxNativeCore/Private/Subsystems/CoreSubsystem.cpp
+++ b/Plugins/VoicevoxNativeCore/Source/VoicevoxNativeCore/Private/Subsystems/CoreSubsystem.cpp
@@ -42,8 +42,11 @@ void UCoreSubsystem::Deinitialize()
 {
 	Super::Deinitialize();
 
-	FPlatformProcess::FreeDllHandle(CoreLibraryHandle);
-	CoreLibraryHandle = nullptr;
+	if (CoreLibraryHandle != nullptr)
+	{
+		FPlatformProcess::FreeDllHandle(CoreLibraryHandle);
+		CoreLibraryHandle = nullptr;
+	}
 }
 
 //--------------------------------

--- a/Plugins/VoicevoxNativeCoreNemo/Source/VoicevoxNativeCoreNemo/Private/Subsystems/NemoCoreSubsystem.cpp
+++ b/Plugins/VoicevoxNativeCoreNemo/Source/VoicevoxNativeCoreNemo/Private/Subsystems/NemoCoreSubsystem.cpp
@@ -42,8 +42,11 @@ void UNemoCoreSubsystem::Deinitialize()
 {
 	Super::Deinitialize();
 
-	FPlatformProcess::FreeDllHandle(CoreLibraryHandle);
-	CoreLibraryHandle = nullptr;
+	if (CoreLibraryHandle != nullptr)
+	{
+		FPlatformProcess::FreeDllHandle(CoreLibraryHandle);
+		CoreLibraryHandle = nullptr;
+	}
 }
 
 //--------------------------------


### PR DESCRIPTION
Windows10&11とMacでUE5.5動作確認、その際に発見した以下の不具合を修正しました。

- Launch実行中にガベコレ対象のＡＰＩを実行するとメモリ参照エラーが出るのを修正
- 動的ライブラリ読み込み失敗時にnullチェックが漏れていたので修正
